### PR TITLE
Unpack spiffs fix

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -342,7 +342,7 @@ bool unpackFile(spiffs_dirent *spiffsFile, const char *destPath) {
 	
     if(dst == NULL)
     {
-        /*Added due to improper handling of "/."*/
+        /*Added due to improper handling of "." */
          std::cout << "Failed to open file, is this the current folder representation \".\"? Ignoring..." << std::endl;
     }
     else

--- a/main.cpp
+++ b/main.cpp
@@ -339,14 +339,19 @@ bool unpackFile(spiffs_dirent *spiffsFile, const char *destPath) {
 
     // Open file.
     FILE* dst = fopen(destPath, "wb");
-
-    // Write content into file.
-    fwrite(buffer, sizeof(u8_t), sizeof(buffer), dst);
-
-    // Close file.
-    fclose(dst);
-
-
+	
+    if(dst == NULL)
+    {
+        /*Added due to improper handling of "/."*/
+         std::cout << "Failed to open file, is this the current folder representation \".\"? Ignoring..." << std::endl;
+    }
+    else
+    {
+        // Write content into file.
+        fwrite(buffer, sizeof(u8_t), sizeof(buffer), dst);
+        // Close file.
+        fclose(dst);
+    }
     return true;
 }
 


### PR DESCRIPTION
Ignore unpacking of current directory file "."

1. The unpacking of current directory "." of a folder always returned a NULL.
2. Add necessary check for NULL pointer return value and ignore the "." file.
3. Sample output:
 spiffs image content:/.
Failed to open file, is this the current folder representation "."? Ignoring...
/.       > ./foo/.  size: 0 Bytes